### PR TITLE
Fix statistics for projects with large class vocabularies

### DIFF
--- a/dataset_tools/image/stats/class_cooccurrence.py
+++ b/dataset_tools/image/stats/class_cooccurrence.py
@@ -14,6 +14,12 @@ REFERENCES_LIMIT = 500
 OBJECTS_TAGS = ["objectsOnly", "all"]
 MAX_NUMBER_OF_TAGS = 500
 
+# Everything this stat holds is class-by-class, so its cost is quadratic: at 500 classes the
+# constructor takes 56 MB and the chart serializes to 3.5 MB, at 3579 it takes 3.3 GB and 188 MB.
+# A matrix that wide is not readable anyway, so it is skipped rather than shrunk — the same call
+# MAX_NUMBER_OF_TAGS already makes for the tag variants below.
+MAX_NUMBER_OF_CLASSES = 500
+
 
 class ClassCooccurrence(BaseStats):
     """
@@ -42,15 +48,28 @@ class ClassCooccurrence(BaseStats):
         self._references = defaultdict(lambda: defaultdict(list))
 
         self._num_classes = len(self._class_names)
-        self.co_occurrence_matrix = np.zeros(
-            (self._num_classes, self._num_classes), dtype=int
-        )  # TODO maybe rm numpy sewing at all?
 
         self._class_ids = {item.sly_id: item.name for item in self._meta.obj_classes.items()}
         self._class_to_index = {}
 
         for idx, obj_class in enumerate(self._meta.obj_classes):
             self._class_to_index[obj_class.sly_id] = idx
+
+        # The two quadratic allocations. Built only under the limit, so an oversized project
+        # costs nothing here instead of the several GB it would otherwise reserve up front.
+        if self._num_classes > MAX_NUMBER_OF_CLASSES:
+            sly.logger.warn(
+                f"{self.__class__.__name__}: skipped, the project has {self._num_classes} classes "
+                f"and the limit is {MAX_NUMBER_OF_CLASSES}."
+            )
+            self.co_occurrence_matrix = np.zeros((0, 0), dtype=int)
+            self._images_set = {}
+            self.co_occurrence_dict = {}
+            return
+
+        self.co_occurrence_matrix = np.zeros(
+            (self._num_classes, self._num_classes), dtype=int
+        )  # TODO maybe rm numpy sewing at all?
 
         self._images_set = {class_id: set() for class_id in self._class_ids}
         self.co_occurrence_dict = {
@@ -61,7 +80,7 @@ class ClassCooccurrence(BaseStats):
     def update2(self, image: ImageInfo, figures: List[FigureInfo]):
         if len(figures) == 0:
             return
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
 
         classes = set()
@@ -77,7 +96,7 @@ class ClassCooccurrence(BaseStats):
                 self.co_occurrence_dict[cls_id_j][cls_id_i].add(image.id)
 
     def to_json2(self):
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
 
         options = {
@@ -157,7 +176,7 @@ class ClassCooccurrence(BaseStats):
         self.__init__(self._meta, self._cls_prevs_tags, self.force)
 
     def to_json(self) -> Optional[Dict]:
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
         # if self.co_occurrence_matrix is None:
         #     return None
@@ -190,7 +209,7 @@ class ClassCooccurrence(BaseStats):
         return res
 
     def to_numpy_raw(self):
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
         return np.array(self.co_occurrence_dict, dtype=object)
         #  if unlabeled
@@ -208,7 +227,7 @@ class ClassCooccurrence(BaseStats):
         # return np.stack([matrix, references], axis=0)
 
     def sew_chunks(self, chunks_dir: str) -> None:
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
         files = sly.fs.list_files(chunks_dir, valid_extensions=[".npy"])
 
@@ -277,6 +296,17 @@ class ClassToTagCooccurrence(BaseStats):
         self._tag_ids = {
             item.sly_id: item.name for item in self._meta.tag_metas if item.name in self._tag_names
         }
+        # Two classes-by-tags dicts, so the cost is the product: 13 MB at 3579 classes and 10
+        # tags, 843 MB at 3579 and 500. The tag side was already capped; this caps the other one.
+        if self._num_classes > MAX_NUMBER_OF_CLASSES:
+            sly.logger.warn(
+                f"{self.__class__.__name__}: skipped, the project has {self._num_classes} classes "
+                f"and the limit is {MAX_NUMBER_OF_CLASSES}."
+            )
+            self.co_occurrence_dict = {}
+            self.references_dict = {}
+            return
+
         self.co_occurrence_dict = {
             class_id_x: {tag_id_y: set() for tag_id_y in self._tag_ids}
             for class_id_x in self._class_ids
@@ -289,7 +319,7 @@ class ClassToTagCooccurrence(BaseStats):
     def update2(self, image: ImageInfo, figures: List[FigureInfo]):
         if len(figures) == 0:
             return
-        if self._num_classes == 0 or self._num_tags == 0 or self._num_tags > MAX_NUMBER_OF_TAGS:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES or self._num_tags == 0 or self._num_tags > MAX_NUMBER_OF_TAGS:
             return
 
         for figure in figures:
@@ -317,7 +347,7 @@ class ClassToTagCooccurrence(BaseStats):
         self.__init__(self._meta, self.force)
 
     def to_json2(self) -> Optional[Dict]:
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
         if self._num_tags == 0 or self._num_tags > MAX_NUMBER_OF_TAGS:
             return
@@ -364,7 +394,7 @@ class ClassToTagCooccurrence(BaseStats):
         return res
 
     def to_numpy_raw(self):
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
         if self._num_tags == 0 or self._num_tags > MAX_NUMBER_OF_TAGS:
             return
@@ -373,7 +403,7 @@ class ClassToTagCooccurrence(BaseStats):
         )
 
     def sew_chunks(self, chunks_dir: str) -> None:
-        if self._num_classes == 0:
+        if self._num_classes == 0 or self._num_classes > MAX_NUMBER_OF_CLASSES:
             return
         if self._num_tags == 0 or self._num_tags > MAX_NUMBER_OF_TAGS:
             return

--- a/dataset_tools/image/stats/overview.py
+++ b/dataset_tools/image/stats/overview.py
@@ -101,7 +101,13 @@ class OverviewPie(BaseStats):
         }
 
         chart_json["options"]["chart"]["height"] = self.CHART_HEIGHT
-        chart_json["referencesCell"] = self._seize_list_to_fixed_size(self._refs, 1000)
+        # One capped list per slice, as every other stat does. Passing _refs itself made the
+        # helper pop integer indices out of a dict keyed by class name, so any project with
+        # more than 1000 classes raised KeyError here. Copies, because the helper pops in place.
+        chart_json["referencesCell"] = {
+            name: self._seize_list_to_fixed_size(list(image_ids), 1000)
+            for name, image_ids in self._refs.items()
+        }
         return chart_json
         
     def to_numpy_raw(self):


### PR DESCRIPTION
Two defects that stop statistics from being produced at all for projects with large class
vocabularies. Found on a real 1000-image project with **3,579 classes**, where the stats run
fails; both were reproduced, fixed and re-verified against that project end to end.

They have to be fixed together — the first one masks the second.

---

## 1. `KeyError` in the overview stats above 1000 classes

```
File "dataset_tools/image/stats/overview.py", line 104, in to_json2
    chart_json["referencesCell"] = self._seize_list_to_fixed_size(self._refs, 1000)
File "dataset_tools/image/stats/basestats.py", line 97, in _seize_list_to_fixed_size
    lst.pop(rng.randint(0, len(lst) - 1))
KeyError: 2619
```

`_seize_list_to_fixed_size` is a list helper — it pops random integer indices until the list
is short enough. `OverviewDonut._refs` is a `defaultdict(list)` keyed by **class name**, one
key per class, so `len()` is the class count and `pop(<int>)` is a dict lookup for a key that
cannot exist. Deterministic (`random.Random(42)`), and the threshold is exactly `> 1000`
classes, so `OverviewPie` (two keys) was always fine and `OverviewDonut` fails every run.

It is the first stat serialized, so it takes down the whole calculation — after ~20 minutes
of completed work.

**Fix:** cap one list per slice, which is what every other caller of this helper already does.

| Caller | Argument |
|---|---|
| `class_balance.py:151` | `list(self._images_set[id])` |
| `datasets_annotations.py:185` | `list(self._images_set[ds_id])` |
| `objects_distribution.py:93` | `list(images_set)` |
| `class_cooccurrence.py:181` | `self._references[i][j]` |
| `overview.py:104` | ~~`self._refs`~~ ← the only mapping |

Copies, because the helper pops in place — passing `self._refs[name]` directly would drop
image ids out of the stat's own state, which `to_numpy_raw` then persists.

`referencesCell` keeps the shape it has today (`{slice name: [image ids]}`), so nothing
downstream changes. One behaviour difference worth naming: the pie's two lists are now capped
at 1000 as well. They were never bounded before — the `while` loop cannot be entered with two
keys — so a large project shipped every annotated image id in that cell.

## 2. Co-occurrence allocates gigabytes before reading an image

With #1 fixed the run gets further and is **OOM-killed** (exit 137).

`ClassCooccurrence` is class-by-class in every structure it holds, and two of them are built
in `__init__`. Measured with real `sly_id`s, since a meta whose classes have `sly_id=None`
collapses `_class_ids` to one entry and hides most of the cost:

| classes | constructor | chart JSON |
|---|---|---|
| 500 | 56 MB | 3.5 MB |
| 1000 | 64 MB | 18.9 MB |
| 3579 | **3.28 GB** | **188.4 MB** |

So a 3579-class project reserves 3.3 GB before it starts, and — if it survives — serializes a
3579×3580 table that no one can read and that then has to be uploaded and fetched by a browser.

`ClassToTagCooccurrence` has the same shape on one axis: two classes-by-tags dicts in
`__init__`, with only the tag side capped. At 3579 classes that is 13 MB against 10 tags but
**843 MB** against 500.

**Fix:** both skip above `MAX_NUMBER_OF_CLASSES = 500`. This is the call `MAX_NUMBER_OF_TAGS`
already makes for the tag variants in the same file, and that `ClassesHeatmaps` (500) and
`ClassesPerImage` (200) make elsewhere — a 3579-class project is already past every one of
those limits.

Constructing and serializing all 13 charts:

| | 3579 classes × 500 tags | 500 × 500 |
|---|---|---|
| before | 1598 MB peak | 671 MB peak |
| after | **613 MB peak** | 671 MB peak — unchanged, nothing skipped |

The boundary is `>`, so a project at exactly the limit keeps both charts.

---

## Verification

Against the real 3,579-class project, through the service that consumes this library, with a
4 GiB limit:

| | result |
|---|---|
| unpatched | `KeyError: 2619` in `to_json2` |
| #1 only | container OOM-killed, `OOMKilled=true ExitCode=137`, no response after 368 s |
| #1 + #2 | `HTTP 200 {"statsUpdated":true,"updatedImages":1000}`, no OOM |

Synthetic checks at the failing scale:

```
OverviewPie:    slices=2     capped=1000  source_unmutated=True
OverviewDonut:  slices=3579  capped=1000  source_unmutated=True
ClassCooccurrence:      skipped, 0 MB constructor (was 3.28 GB)
ClassToTagCooccurrence: skipped, 0 MB constructor (was 843 MB)
```

A sweep of all 13 charts at 3579 classes confirms these are the only two that scale
badly with class count; the rest cost under 3 MB each.
